### PR TITLE
全ての楽曲をアンロックするボタンを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ google-services.json
 *.hprof
 
 .DS_Store
+app/release
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "com.suzukiplan.TOHOVGS"
         minSdk 26
         targetSdk 31
-        versionCode 403
-        versionName "4.3"
+        versionCode 404
+        versionName "4.4"
         ndk {
             moduleName "native-lib"
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,3 +1,1 @@
--keep class com.google.**  { *; }
--keep interface com.google.**  { *; }
--keep class com.suzukiplan.tohovgs.model.** { *; }
+-keepnames class com.suzukiplan.tohovgs.model.** { *; }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,3 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
-
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
-
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-keep class com.google.**  { *; }
+-keep interface com.google.**  { *; }
+-keep class com.suzukiplan.tohovgs.model.** { *; }

--- a/app/src/main/java/com/suzukiplan/tohovgs/AlbumPagerFragment.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/AlbumPagerFragment.kt
@@ -4,7 +4,6 @@
  */
 package com.suzukiplan.tohovgs
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -69,21 +68,11 @@ class AlbumPagerFragment : Fragment() {
         TabLayoutMediator(tabLayout, pager) { tab, position ->
             tab.text = items[position].name
         }.attach()
-        reload(MusicManager.getInstance(mainActivity)?.isExistLockedSong(settings))
-        return view
-    }
-
-    @SuppressLint("NotifyDataSetChanged")
-    fun reload(allUnlocked: Boolean?) {
+        val allUnlocked = MusicManager.getInstance(mainActivity)?.isExistLockedSong(settings)
         unlockAllContainer.visibility =
             if (true == allUnlocked) {
                 unlockAll.setOnClickListener {
-                    mainActivity.onRequestUnlockAll {
-                        if (it) {
-                            unlockAllContainer.visibility = View.GONE
-                            pager.adapter?.notifyDataSetChanged()
-                        }
-                    }
+                    mainActivity.onRequestUnlockAll()
                 }
                 hideUnlockAll.setOnClickListener {
                     unlockAllContainer.visibility = View.GONE
@@ -92,6 +81,7 @@ class AlbumPagerFragment : Fragment() {
             } else {
                 View.GONE
             }
+        return view
     }
 
     inner class Adapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {

--- a/app/src/main/java/com/suzukiplan/tohovgs/AlbumPagerFragment.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/AlbumPagerFragment.kt
@@ -4,10 +4,12 @@
  */
 package com.suzukiplan.tohovgs
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -26,6 +28,7 @@ class AlbumPagerFragment : Fragment() {
     }
 
     private lateinit var mainActivity: MainActivity
+    private lateinit var unlockAll: Button
     private lateinit var tabLayout: TabLayout
     private lateinit var pager: ViewPager2
     private lateinit var settings: Settings
@@ -42,6 +45,7 @@ class AlbumPagerFragment : Fragment() {
         settings = Settings(context)
         musicManager = MusicManager.getInstance(mainActivity)
         val view = inflater.inflate(R.layout.fragment_album_pager, container, false)
+        unlockAll = view.findViewById(R.id.unlock_all)
         tabLayout = view.findViewById(R.id.tab)
         pager = view.findViewById(R.id.pager)
         items = musicManager?.albums!!
@@ -60,7 +64,26 @@ class AlbumPagerFragment : Fragment() {
         TabLayoutMediator(tabLayout, pager) { tab, position ->
             tab.text = items[position].name
         }.attach()
+        reload(MusicManager.getInstance(mainActivity)?.isExistLockedSong(settings))
         return view
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun reload(allUnlocked: Boolean?) {
+        unlockAll.visibility =
+            if (true == allUnlocked) {
+                unlockAll.setOnClickListener {
+                    mainActivity.onRequestUnlockAll {
+                        if (it) {
+                            unlockAll.visibility = View.GONE
+                            pager.adapter?.notifyDataSetChanged()
+                        }
+                    }
+                }
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
     }
 
     inner class Adapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {

--- a/app/src/main/java/com/suzukiplan/tohovgs/AlbumPagerFragment.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/AlbumPagerFragment.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.ImageButton
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.viewpager2.adapter.FragmentStateAdapter
@@ -28,7 +29,9 @@ class AlbumPagerFragment : Fragment() {
     }
 
     private lateinit var mainActivity: MainActivity
+    private lateinit var unlockAllContainer: View
     private lateinit var unlockAll: Button
+    private lateinit var hideUnlockAll: ImageButton
     private lateinit var tabLayout: TabLayout
     private lateinit var pager: ViewPager2
     private lateinit var settings: Settings
@@ -45,7 +48,9 @@ class AlbumPagerFragment : Fragment() {
         settings = Settings(context)
         musicManager = MusicManager.getInstance(mainActivity)
         val view = inflater.inflate(R.layout.fragment_album_pager, container, false)
+        unlockAllContainer = view.findViewById(R.id.unlock_all_container)
         unlockAll = view.findViewById(R.id.unlock_all)
+        hideUnlockAll = view.findViewById(R.id.unlock_all_hide)
         tabLayout = view.findViewById(R.id.tab)
         pager = view.findViewById(R.id.pager)
         items = musicManager?.albums!!
@@ -70,15 +75,18 @@ class AlbumPagerFragment : Fragment() {
 
     @SuppressLint("NotifyDataSetChanged")
     fun reload(allUnlocked: Boolean?) {
-        unlockAll.visibility =
+        unlockAllContainer.visibility =
             if (true == allUnlocked) {
                 unlockAll.setOnClickListener {
                     mainActivity.onRequestUnlockAll {
                         if (it) {
-                            unlockAll.visibility = View.GONE
+                            unlockAllContainer.visibility = View.GONE
                             pager.adapter?.notifyDataSetChanged()
                         }
                     }
+                }
+                hideUnlockAll.setOnClickListener {
+                    unlockAllContainer.visibility = View.GONE
                 }
                 View.VISIBLE
             } else {

--- a/app/src/main/java/com/suzukiplan/tohovgs/MainActivity.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/MainActivity.kt
@@ -178,6 +178,9 @@ class MainActivity : AppCompatActivity(), SongListFragment.Listener {
             override fun onClick(isYes: Boolean) {
                 if (isYes) {
                     settings.lock(song)
+                    (currentFragment as? AlbumPagerFragment)?.reload(
+                        musicManager?.isExistLockedSong(settings)
+                    )
                     done()
                 }
             }

--- a/app/src/main/java/com/suzukiplan/tohovgs/MainActivity.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/MainActivity.kt
@@ -141,7 +141,6 @@ class MainActivity : AppCompatActivity(), SongListFragment.Listener {
 
     private fun movePage(page: Page) {
         if (page == currentPage) return
-        val currentFragment = this.currentFragment ?: return
         stopSong()
         val fragment = when (page) {
             Page.PerTitle -> AlbumPagerFragment.create()
@@ -158,7 +157,7 @@ class MainActivity : AppCompatActivity(), SongListFragment.Listener {
             transaction.setCustomAnimations(R.anim.slide_in_from_left, R.anim.slide_out_to_right)
         }
         transaction.replace(fragmentContainer.id, fragment)
-        this.currentFragment = fragment
+        currentFragment = fragment
         transaction.commit()
         footers[currentPage]?.setBackgroundResource(R.drawable.bottom_menu_unselected)
         footers[page]?.setBackgroundResource(R.drawable.bottom_menu_selected)

--- a/app/src/main/java/com/suzukiplan/tohovgs/SongListFragment.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/SongListFragment.kt
@@ -47,7 +47,7 @@ class SongListFragment : Fragment() {
     }
 
     interface Listener {
-        fun onRequestUnlockAll(done: (unlocked: Boolean) -> Unit)
+        fun onRequestUnlockAll()
         fun onRequestUnlock(album: Album, done: (unlocked: Boolean) -> Unit)
         fun onRequestLock(song: Song, done: () -> Unit)
         fun onPlay(album: Album, song: Song, onPlayEnded: () -> Unit)

--- a/app/src/main/java/com/suzukiplan/tohovgs/SongListFragment.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/SongListFragment.kt
@@ -47,6 +47,7 @@ class SongListFragment : Fragment() {
     }
 
     interface Listener {
+        fun onRequestUnlockAll(done: (unlocked: Boolean) -> Unit)
         fun onRequestUnlock(album: Album, done: (unlocked: Boolean) -> Unit)
         fun onRequestLock(song: Song, done: () -> Unit)
         fun onPlay(album: Album, song: Song, onPlayEnded: () -> Unit)

--- a/app/src/main/java/com/suzukiplan/tohovgs/api/MusicManager.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/api/MusicManager.kt
@@ -4,6 +4,7 @@
  */
 package com.suzukiplan.tohovgs.api
 
+import android.annotation.SuppressLint
 import android.app.job.JobInfo
 import android.app.job.JobScheduler
 import android.content.ComponentName
@@ -18,6 +19,7 @@ import com.suzukiplan.tohovgs.model.Song
 
 class MusicManager {
     companion object {
+        @SuppressLint("StaticFieldLeak")
         private var instance: MusicManager? = null
 
         fun getInstance(mainActivity: MainActivity): MusicManager? {

--- a/app/src/main/java/com/suzukiplan/tohovgs/api/MusicManager.kt
+++ b/app/src/main/java/com/suzukiplan/tohovgs/api/MusicManager.kt
@@ -50,6 +50,12 @@ class MusicManager {
     var isBackground = false
     private var startedContext: Context? = null
 
+    fun isExistLockedSong(settings: Settings): Boolean {
+        return null != albums?.find { album ->
+            null != album.songs.find { settings.isLocked(it) }
+        }
+    }
+
     private fun load(mainActivity: MainActivity) {
         val songListInput = mainActivity.assets.open("songlist.json")
         val songListJson = String(songListInput.readBytes(), Charsets.UTF_8)

--- a/app/src/main/res/drawable/ic_baseline_close_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_close_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_album_pager.xml
+++ b/app/src/main/res/layout/fragment_album_pager.xml
@@ -4,6 +4,13 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <Button
+        android:id="@+id/unlock_all"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/unlock_all_songs" />
+
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tab"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_album_pager.xml
+++ b/app/src/main/res/layout/fragment_album_pager.xml
@@ -4,12 +4,32 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <Button
-        android:id="@+id/unlock_all"
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:id="@+id/unlock_all_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="8dp"
-        android:text="@string/unlock_all_songs" />
+        android:background="@color/black"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/unlock_all"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_margin="8dp"
+            android:layout_weight="1"
+            android:text="@string/unlock_all_songs" />
+
+        <ImageButton
+            android:id="@+id/unlock_all_hide"
+            android:layout_width="44dp"
+            android:layout_height="44dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="8dp"
+            android:contentDescription="@string/hide_unlock_all_button"
+            android:src="@drawable/ic_baseline_close_24" />
+
+    </androidx.appcompat.widget.LinearLayoutCompat>
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tab"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -16,4 +16,5 @@
     <string name="error_ads">広告の読み込みに失敗しました。</string>
     <string name="seek_bar">シークバー</string>
     <string name="unlock_all_songs">全ての楽曲をアンロックする</string>
+    <string name="hide_unlock_all_button">一時的に全ての楽曲アンロックボタンを隠す</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -8,10 +8,12 @@
     <string name="ok">OK</string>
     <string name="cancel">キャンセル</string>
     <string name="ask_unlock">リワード広告を再生することで「%s」の全楽曲をアンロックすることができます。</string>
+    <string name="ask_unlock_all">リワード広告を再生することで全楽曲をアンロックすることができます。</string>
     <string name="ask_lock">「%s」をロックしてもよろしいですか?</string>
     <string name="generating_shuffle_play_list">シャッフル・プレイリストを生成中…</string>
     <string name="all_songs_are_locked">全ての楽曲がロックされています</string>
     <string name="infinity">INFINITY</string>
     <string name="error_ads">広告の読み込みに失敗しました。</string>
     <string name="seek_bar">シークバー</string>
+    <string name="unlock_all_songs">全ての楽曲をアンロックする</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,10 +8,12 @@
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="ask_unlock">You can unlock all songs in %s by playing reward ads.\nAre you sure you want to play it?</string>
+    <string name="ask_unlock_all">You can unlock all songs by playing reward ads.\nAre you sure you want to play it?</string>
     <string name="ask_lock">Are you sure you want to lock the %s?\n\nNote: You will need to play the reward ad when you unlock it again.</string>
     <string name="generating_shuffle_play_list">Generating shuffle play list…</string>
     <string name="all_songs_are_locked">All songs are locked</string>
     <string name="infinity">INFINITY</string>
     <string name="error_ads">Failed to load ads.</string>
     <string name="seek_bar">Seek Bar</string>
+    <string name="unlock_all_songs">Unlock All Songs</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="error_ads">Failed to load ads.</string>
     <string name="seek_bar">Seek Bar</string>
     <string name="unlock_all_songs">Unlock All Songs</string>
+    <string name="hide_unlock_all_button">Hide unlock all button</string>
 </resources>


### PR DESCRIPTION
思っていたよりもリワード広告の再生時間が長いようで、1タイトルづつアンロックするのが中々しんどいらしい。
なので、全楽曲を一括でアンロックできる機能を入れる。